### PR TITLE
Add Phase 2B.2 domain components: ListCard, ListItemRow, MultiSelectBar

### DIFF
--- a/src/components/domain/ListCard.spec.tsx
+++ b/src/components/domain/ListCard.spec.tsx
@@ -1,0 +1,342 @@
+import React from 'react';
+import { render, type RenderResult } from '@testing-library/react';
+import userEvent, { type UserEvent } from '@testing-library/user-event';
+
+import { ListCard, type IListCardProps } from './ListCard';
+import { createList } from 'test-utils/factories';
+
+interface ISetupReturn extends RenderResult {
+  props: IListCardProps;
+  user: UserEvent;
+}
+
+function setup(suppliedProps: Partial<IListCardProps> = {}): ISetupReturn {
+  const user = userEvent.setup();
+  const defaultProps: IListCardProps = {
+    list: createList('list1', 'Test List'),
+    userId: 'id1',
+    currentUserPermissions: { list1: 'write' },
+    isMultiSelectActive: false,
+    isSelected: false,
+    onSelect: vi.fn(),
+    onComplete: vi.fn(),
+    onShare: vi.fn(),
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    onRefresh: vi.fn(),
+    onAccept: vi.fn(),
+    onReject: vi.fn(),
+    onClick: vi.fn(),
+  };
+  const props = { ...defaultProps, ...suppliedProps };
+  const component = render(<ListCard {...props} />);
+  return { ...component, props, user };
+}
+
+describe('ListCard', () => {
+  describe('rendering', () => {
+    it('renders list name', async () => {
+      const { findByText } = setup();
+      expect(await findByText('Test List')).toBeVisible();
+    });
+
+    it('renders with data-test-id list-{id}', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-id="list-list1"]')).toBeInTheDocument();
+    });
+
+    it('renders list-name data-test-id', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-id="list-name"]')).toBeInTheDocument();
+    });
+
+    it('shows refreshed indicator when list is refreshed', async () => {
+      const { findByLabelText } = setup({ list: createList('list1', 'Test List', 'config1', { refreshed: true }) });
+      expect(await findByLabelText('Refreshed')).toBeVisible();
+    });
+
+    it('does not show refreshed indicator when list is not refreshed', () => {
+      const { queryByLabelText } = setup();
+      expect(queryByLabelText('Refreshed')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('incomplete list (owned)', () => {
+    it('has incomplete-list data-test-class', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-class="incomplete-list"]')).toBeInTheDocument();
+    });
+
+    it('renders Complete button', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-id="incomplete-list-complete"]')).toBeInTheDocument();
+    });
+
+    it('renders Share button', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-id="incomplete-list-share"]')).toBeInTheDocument();
+    });
+
+    it('renders Edit button', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-id="incomplete-list-edit"]')).toBeInTheDocument();
+    });
+
+    it('renders Delete button', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-id="incomplete-list-trash"]')).toBeInTheDocument();
+    });
+
+    it('calls onComplete when Complete is clicked', async () => {
+      const { container, props, user } = setup();
+      const btn = container.querySelector('[data-test-id="incomplete-list-complete"]') as HTMLElement;
+      await user.click(btn);
+      expect(props.onComplete).toHaveBeenCalledWith('list1');
+    });
+
+    it('calls onShare when Share is clicked', async () => {
+      const { container, props, user } = setup();
+      const btn = container.querySelector('[data-test-id="incomplete-list-share"]') as HTMLElement;
+      await user.click(btn);
+      expect(props.onShare).toHaveBeenCalledWith('list1');
+    });
+
+    it('calls onEdit when Edit is clicked', async () => {
+      const { container, props, user } = setup();
+      const btn = container.querySelector('[data-test-id="incomplete-list-edit"]') as HTMLElement;
+      await user.click(btn);
+      expect(props.onEdit).toHaveBeenCalledWith('list1');
+    });
+
+    it('calls onDelete when Delete is clicked', async () => {
+      const { container, props, user } = setup();
+      const btn = container.querySelector('[data-test-id="incomplete-list-trash"]') as HTMLElement;
+      await user.click(btn);
+      expect(props.onDelete).toHaveBeenCalledWith('list1');
+    });
+  });
+
+  describe('incomplete list (shared, write)', () => {
+    function sharedWriteSetup(overrides: Partial<IListCardProps> = {}): ISetupReturn {
+      return setup({
+        list: createList('list1', 'Shared List', 'config1', { owner_id: 'other-user' }),
+        currentUserPermissions: { list1: 'write' },
+        ...overrides,
+      });
+    }
+
+    it('renders Share button for shared write user', () => {
+      const { container } = sharedWriteSetup();
+      expect(container.querySelector('[data-test-id="incomplete-list-share"]')).toBeInTheDocument();
+    });
+
+    it('renders Delete button', () => {
+      const { container } = sharedWriteSetup();
+      expect(container.querySelector('[data-test-id="incomplete-list-trash"]')).toBeInTheDocument();
+    });
+
+    it('does not render Complete button (not owner)', () => {
+      const { container } = sharedWriteSetup();
+      expect(container.querySelector('[data-test-id="incomplete-list-complete"]')).not.toBeInTheDocument();
+    });
+
+    it('does not render Edit button (not owner)', () => {
+      const { container } = sharedWriteSetup();
+      expect(container.querySelector('[data-test-id="incomplete-list-edit"]')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('incomplete list (shared, read)', () => {
+    function sharedReadSetup(overrides: Partial<IListCardProps> = {}): ISetupReturn {
+      return setup({
+        list: createList('list1', 'Read Only List', 'config1', { owner_id: 'other-user' }),
+        currentUserPermissions: { list1: 'read' },
+        ...overrides,
+      });
+    }
+
+    it('renders Delete button', () => {
+      const { container } = sharedReadSetup();
+      expect(container.querySelector('[data-test-id="incomplete-list-trash"]')).toBeInTheDocument();
+    });
+
+    it('does not render Complete button', () => {
+      const { container } = sharedReadSetup();
+      expect(container.querySelector('[data-test-id="incomplete-list-complete"]')).not.toBeInTheDocument();
+    });
+
+    it('does not render Share button', () => {
+      const { container } = sharedReadSetup();
+      expect(container.querySelector('[data-test-id="incomplete-list-share"]')).not.toBeInTheDocument();
+    });
+
+    it('does not render Edit button', () => {
+      const { container } = sharedReadSetup();
+      expect(container.querySelector('[data-test-id="incomplete-list-edit"]')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('completed list (owned)', () => {
+    function completedSetup(overrides: Partial<IListCardProps> = {}): ISetupReturn {
+      return setup({
+        list: createList('list1', 'Done List', 'config1', { completed: true }),
+        currentUserPermissions: { list1: 'write' },
+        ...overrides,
+      });
+    }
+
+    it('has completed-list data-test-class', () => {
+      const { container } = completedSetup();
+      expect(container.querySelector('[data-test-class="completed-list"]')).toBeInTheDocument();
+    });
+
+    it('renders Refresh button', () => {
+      const { container } = completedSetup();
+      expect(container.querySelector('[data-test-id="complete-list-refresh"]')).toBeInTheDocument();
+    });
+
+    it('renders Delete button', () => {
+      const { container } = completedSetup();
+      expect(container.querySelector('[data-test-id="complete-list-trash"]')).toBeInTheDocument();
+    });
+
+    it('calls onRefresh when Refresh is clicked', async () => {
+      const { container, props, user } = completedSetup();
+      const btn = container.querySelector('[data-test-id="complete-list-refresh"]') as HTMLElement;
+      await user.click(btn);
+      expect(props.onRefresh).toHaveBeenCalledWith('list1');
+    });
+
+    it('calls onDelete when Delete is clicked', async () => {
+      const { container, props, user } = completedSetup();
+      const btn = container.querySelector('[data-test-id="complete-list-trash"]') as HTMLElement;
+      await user.click(btn);
+      expect(props.onDelete).toHaveBeenCalledWith('list1');
+    });
+  });
+
+  describe('completed list (shared)', () => {
+    function completedSharedSetup(): ISetupReturn {
+      return setup({
+        list: createList('list1', 'Shared Done', 'config1', { completed: true, owner_id: 'other-user' }),
+        currentUserPermissions: { list1: 'read' },
+      });
+    }
+
+    it('renders Delete button', () => {
+      const { container } = completedSharedSetup();
+      expect(container.querySelector('[data-test-id="complete-list-trash"]')).toBeInTheDocument();
+    });
+  });
+
+  describe('pending list', () => {
+    function pendingSetup(overrides: Partial<IListCardProps> = {}): ISetupReturn {
+      return setup({
+        list: createList('list1', 'Pending List'),
+        currentUserPermissions: {},
+        ...overrides,
+      });
+    }
+
+    it('has pending-list data-test-class', () => {
+      const { container } = pendingSetup();
+      expect(container.querySelector('[data-test-class="pending-list"]')).toBeInTheDocument();
+    });
+
+    it('renders Accept button', () => {
+      const { container } = pendingSetup();
+      expect(container.querySelector('[data-test-id="pending-list-accept"]')).toBeInTheDocument();
+    });
+
+    it('renders Reject button', () => {
+      const { container } = pendingSetup();
+      expect(container.querySelector('[data-test-id="pending-list-trash"]')).toBeInTheDocument();
+    });
+
+    it('calls onAccept when Accept is clicked', async () => {
+      const { container, props, user } = pendingSetup();
+      const btn = container.querySelector('[data-test-id="pending-list-accept"]') as HTMLElement;
+      await user.click(btn);
+      expect(props.onAccept).toHaveBeenCalledWith('list1');
+    });
+
+    it('calls onReject when Reject is clicked', async () => {
+      const { container, props, user } = pendingSetup();
+      const btn = container.querySelector('[data-test-id="pending-list-trash"]') as HTMLElement;
+      await user.click(btn);
+      expect(props.onReject).toHaveBeenCalledWith('list1');
+    });
+  });
+
+  describe('multi-select', () => {
+    it('shows checkbox when multi-select is active', () => {
+      const { container } = setup({ isMultiSelectActive: true });
+      expect(container.querySelector('input[type="checkbox"]')).toBeInTheDocument();
+    });
+
+    it('does not show checkbox when multi-select is inactive', () => {
+      const { container } = setup({ isMultiSelectActive: false });
+      expect(container.querySelector('input[type="checkbox"]')).not.toBeInTheDocument();
+    });
+
+    it('checkbox is checked when selected', () => {
+      const { container } = setup({ isMultiSelectActive: true, isSelected: true });
+      const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+    });
+
+    it('checkbox is unchecked when not selected', () => {
+      const { container } = setup({ isMultiSelectActive: true, isSelected: false });
+      const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+      expect(checkbox.checked).toBe(false);
+    });
+
+    it('calls onSelect when checkbox is clicked', async () => {
+      const { container, props, user } = setup({ isMultiSelectActive: true });
+      const checkbox = container.querySelector('input[type="checkbox"]') as HTMLElement;
+      await user.click(checkbox);
+      expect(props.onSelect).toHaveBeenCalledWith('list1');
+    });
+
+    it('calls onSelect when card is clicked in multi-select mode', async () => {
+      const { container, props, user } = setup({ isMultiSelectActive: true });
+      const card = container.querySelector('[data-test-id="list-list1"]') as HTMLElement;
+      await user.click(card);
+      expect(props.onSelect).toHaveBeenCalled();
+    });
+
+    it('shows merge button in multi-select mode', () => {
+      const { container } = setup({ isMultiSelectActive: true });
+      expect(container.querySelector('[data-test-id="incomplete-list-merge"]')).toBeInTheDocument();
+    });
+
+    it('hides regular action buttons in multi-select mode', () => {
+      const { container } = setup({ isMultiSelectActive: true });
+      expect(container.querySelector('[data-test-id="incomplete-list-complete"]')).not.toBeInTheDocument();
+      expect(container.querySelector('[data-test-id="incomplete-list-share"]')).not.toBeInTheDocument();
+      expect(container.querySelector('[data-test-id="incomplete-list-edit"]')).not.toBeInTheDocument();
+    });
+
+    it('applies selected visual state when isSelected is true', () => {
+      const { container } = setup({ isMultiSelectActive: true, isSelected: true });
+      const card = container.querySelector('[data-test-id="list-list1"]');
+      expect(card?.className).toContain('border-[var(--color-primary)]');
+    });
+  });
+
+  describe('navigation', () => {
+    it('calls onClick when card is clicked (not in multi-select)', async () => {
+      const { container, props, user } = setup();
+      const card = container.querySelector('[data-test-id="list-list1"]') as HTMLElement;
+      await user.click(card);
+      expect(props.onClick).toHaveBeenCalledWith('list1');
+    });
+
+    it('has role="button" and tabIndex for keyboard access', () => {
+      const { container } = setup();
+      const card = container.querySelector('[data-test-id="list-list1"]');
+      expect(card).toHaveAttribute('role', 'button');
+      expect(card).toHaveAttribute('tabindex', '0');
+    });
+  });
+});

--- a/src/components/domain/ListCard.tsx
+++ b/src/components/domain/ListCard.tsx
@@ -1,0 +1,242 @@
+import React from 'react';
+
+import { Card } from '../ui/Card';
+import { IconButton } from '../ui/IconButton';
+import { CheckIcon, EditIcon, RedoIcon, TrashIcon, UsersIcon, CompressIcon } from '../icons';
+import type { IList, TUserPermissions } from 'typings';
+
+export interface IListCardProps {
+  list: IList;
+  userId: string;
+  currentUserPermissions: TUserPermissions;
+  isMultiSelectActive: boolean;
+  isSelected: boolean;
+  onSelect: (listId: string) => void;
+  onComplete: (listId: string) => void;
+  onShare: (listId: string) => void;
+  onEdit: (listId: string) => void;
+  onDelete: (listId: string) => void;
+  onRefresh: (listId: string) => void;
+  onAccept: (listId: string) => void;
+  onReject: (listId: string) => void;
+  onClick: (listId: string) => void;
+}
+
+function isPending(list: IList, permissions: TUserPermissions): boolean {
+  return list.id !== undefined && !(list.id in permissions);
+}
+
+function getTestClass(list: IList, permissions: TUserPermissions): string {
+  if (isPending(list, permissions)) {
+    return 'pending-list';
+  }
+  return list.completed ? 'completed-list' : 'incomplete-list';
+}
+
+export function ListCard(props: IListCardProps): React.JSX.Element {
+  const {
+    list,
+    userId,
+    currentUserPermissions,
+    isMultiSelectActive,
+    isSelected,
+    onSelect,
+    onComplete,
+    onShare,
+    onEdit,
+    onDelete,
+    onRefresh,
+    onAccept,
+    onReject,
+    onClick,
+  } = props;
+
+  const listId = list.id ?? '';
+  const pending = isPending(list, currentUserPermissions);
+  const permission = currentUserPermissions[listId];
+  const isOwner = userId === list.owner_id;
+  const canShare = permission === 'write';
+  const testClass = getTestClass(list, currentUserPermissions);
+
+  const handleClick = (): void => {
+    if (isMultiSelectActive) {
+      onSelect(listId);
+    } else {
+      onClick(listId);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent): void => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleClick();
+    }
+  };
+
+  const renderActionButtons = (): React.JSX.Element | null => {
+    if (isMultiSelectActive) {
+      return (
+        <IconButton
+          icon={<CompressIcon size="sm" />}
+          variant="primary"
+          size="sm"
+          label="Merge"
+          data-test-id="incomplete-list-merge"
+          onClick={(e): void => {
+            e.stopPropagation();
+          }}
+        />
+      );
+    }
+
+    if (pending) {
+      return (
+        <div className="tw:flex tw:items-center tw:gap-1">
+          <IconButton
+            icon={<CheckIcon size="sm" />}
+            variant="success"
+            size="sm"
+            label="Accept"
+            data-test-id="pending-list-accept"
+            onClick={(e): void => {
+              e.stopPropagation();
+              onAccept(listId);
+            }}
+          />
+          <IconButton
+            icon={<TrashIcon size="sm" />}
+            variant="danger"
+            size="sm"
+            label="Reject"
+            data-test-id="pending-list-trash"
+            onClick={(e): void => {
+              e.stopPropagation();
+              onReject(listId);
+            }}
+          />
+        </div>
+      );
+    }
+
+    if (list.completed) {
+      return (
+        <div className="tw:flex tw:items-center tw:gap-1">
+          <IconButton
+            icon={<RedoIcon size="sm" />}
+            variant="primary"
+            size="sm"
+            label="Refresh"
+            data-test-id="complete-list-refresh"
+            onClick={(e): void => {
+              e.stopPropagation();
+              onRefresh(listId);
+            }}
+          />
+          <IconButton
+            icon={<TrashIcon size="sm" />}
+            variant="danger"
+            size="sm"
+            label="Delete"
+            data-test-id="complete-list-trash"
+            onClick={(e): void => {
+              e.stopPropagation();
+              onDelete(listId);
+            }}
+          />
+        </div>
+      );
+    }
+
+    return (
+      <div className="tw:flex tw:items-center tw:gap-1">
+        {isOwner && (
+          <IconButton
+            icon={<CheckIcon size="sm" />}
+            variant="success"
+            size="sm"
+            label="Complete"
+            data-test-id="incomplete-list-complete"
+            onClick={(e): void => {
+              e.stopPropagation();
+              onComplete(listId);
+            }}
+          />
+        )}
+        {canShare && (
+          <IconButton
+            icon={<UsersIcon size="sm" />}
+            variant="primary"
+            size="sm"
+            label="Share"
+            data-test-id="incomplete-list-share"
+            onClick={(e): void => {
+              e.stopPropagation();
+              onShare(listId);
+            }}
+          />
+        )}
+        {isOwner && (
+          <IconButton
+            icon={<EditIcon size="sm" />}
+            variant="default"
+            size="sm"
+            label="Edit"
+            data-test-id="incomplete-list-edit"
+            onClick={(e): void => {
+              e.stopPropagation();
+              onEdit(listId);
+            }}
+          />
+        )}
+        <IconButton
+          icon={<TrashIcon size="sm" />}
+          variant="danger"
+          size="sm"
+          label="Delete"
+          data-test-id="incomplete-list-trash"
+          onClick={(e): void => {
+            e.stopPropagation();
+            onDelete(listId);
+          }}
+        />
+      </div>
+    );
+  };
+
+  const pendingBorderStyle = pending ? ' tw:border-l-4 tw:border-l-[var(--color-warning)]' : '';
+
+  return (
+    <Card
+      variant="interactive"
+      selected={isMultiSelectActive && isSelected}
+      completed={list.completed ?? false}
+      data-test-id={`list-${listId}`}
+      data-test-class={testClass}
+      className={`tw:flex tw:items-center tw:gap-3${pendingBorderStyle}`}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
+    >
+      {isMultiSelectActive && (
+        <input
+          type="checkbox"
+          className="tw:w-5 tw:h-5 tw:cursor-pointer tw:flex-shrink-0"
+          checked={isSelected}
+          onChange={(): void => onSelect(listId)}
+          onClick={(e): void => e.stopPropagation()}
+          aria-label={`Select ${list.name}`}
+        />
+      )}
+      <div className="tw:flex-1 tw:min-w-0">
+        <div className="tw:flex tw:items-center tw:gap-2">
+          <span className="tw:text-base tw:font-semibold tw:truncate" data-test-id="list-name">
+            {list.refreshed && <span aria-label="Refreshed">* </span>}
+            {list.name}
+          </span>
+        </div>
+      </div>
+      <div className="tw:flex-shrink-0">{renderActionButtons()}</div>
+    </Card>
+  );
+}

--- a/src/components/domain/ListItemRow.spec.tsx
+++ b/src/components/domain/ListItemRow.spec.tsx
@@ -1,0 +1,250 @@
+import React from 'react';
+import { render, type RenderResult } from '@testing-library/react';
+import userEvent, { type UserEvent } from '@testing-library/user-event';
+
+import { ListItemRow, type IListItemRowProps } from './ListItemRow';
+import { createListItem, createField } from 'test-utils/factories';
+import { EListItemFieldType } from 'typings';
+
+interface ISetupReturn extends RenderResult {
+  props: IListItemRowProps;
+  user: UserEvent;
+}
+
+function setup(suppliedProps: Partial<IListItemRowProps> = {}): ISetupReturn {
+  const user = userEvent.setup();
+  const item = createListItem('item1', false, [
+    createField('f1', 'product', 'Apples', 'item1', { primary: true }),
+    createField('f2', 'quantity', '3', 'item1'),
+  ]);
+  const defaultProps: IListItemRowProps = {
+    item,
+    listId: 'id1',
+    fields: item.fields,
+    fieldConfigurations: [],
+    isMultiSelectActive: false,
+    isSelected: false,
+    onSelect: vi.fn(),
+    onComplete: vi.fn(),
+    onRefresh: vi.fn(),
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    permissions: { id1: 'write' },
+  };
+  const props = { ...defaultProps, ...suppliedProps };
+  const component = render(<ListItemRow {...props} />);
+  return { ...component, props, user };
+}
+
+describe('ListItemRow', () => {
+  describe('rendering', () => {
+    it('renders primary field value', async () => {
+      const { findByText } = setup();
+      expect(await findByText('Apples')).toBeVisible();
+    });
+
+    it('renders secondary fields', async () => {
+      const { findByText } = setup();
+      expect(await findByText('3')).toBeVisible();
+    });
+
+    it('renders "Untitled Item" when no fields have data', async () => {
+      const item = createListItem('item1', false, []);
+      const { findByText } = setup({ item, fields: item.fields });
+      expect(await findByText('Untitled Item')).toBeVisible();
+    });
+
+    it('renders category badge when category exists', async () => {
+      const item = createListItem('item1', false, [createField('f1', 'product', 'Milk', 'item1', { primary: true })], {
+        category: 'Dairy',
+      });
+      const { findByText } = setup({ item, fields: item.fields });
+      expect(await findByText('Dairy')).toBeVisible();
+    });
+
+    it('does not render category badge when no category', () => {
+      const { queryByText } = setup();
+      expect(queryByText('Dairy')).not.toBeInTheDocument();
+    });
+
+    it('has non-completed-item data-test-class for incomplete items', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-class="non-completed-item"]')).toBeInTheDocument();
+    });
+
+    it('has completed-item data-test-class for completed items', () => {
+      const item = createListItem('item1', true, [
+        createField('f1', 'product', 'Done Item', 'item1', { primary: true }),
+      ]);
+      const { container } = setup({ item, fields: item.fields });
+      expect(container.querySelector('[data-test-class="completed-item"]')).toBeInTheDocument();
+    });
+  });
+
+  describe('not completed item actions', () => {
+    it('renders Complete button', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-id="not-completed-item-complete-item1"]')).toBeInTheDocument();
+    });
+
+    it('renders Edit button', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-id="not-completed-item-edit-item1"]')).toBeInTheDocument();
+    });
+
+    it('renders Delete button', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-id="not-completed-item-delete-item1"]')).toBeInTheDocument();
+    });
+
+    it('calls onComplete when Complete is clicked', async () => {
+      const { container, props, user } = setup();
+      const btn = container.querySelector('[data-test-id="not-completed-item-complete-item1"]') as HTMLElement;
+      await user.click(btn);
+      expect(props.onComplete).toHaveBeenCalledWith('item1');
+    });
+
+    it('calls onEdit when Edit is clicked', async () => {
+      const { container, props, user } = setup();
+      const btn = container.querySelector('[data-test-id="not-completed-item-edit-item1"]') as HTMLElement;
+      await user.click(btn);
+      expect(props.onEdit).toHaveBeenCalledWith('item1');
+    });
+
+    it('calls onDelete when Delete is clicked', async () => {
+      const { container, props, user } = setup();
+      const btn = container.querySelector('[data-test-id="not-completed-item-delete-item1"]') as HTMLElement;
+      await user.click(btn);
+      expect(props.onDelete).toHaveBeenCalledWith('item1');
+    });
+  });
+
+  describe('completed item actions (refreshable)', () => {
+    function completedSetup(overrides: Partial<IListItemRowProps> = {}): ISetupReturn {
+      const item = createListItem('item1', true, [
+        createField('f1', 'product', 'Done Item', 'item1', { primary: true }),
+      ]);
+      return setup({ item, fields: item.fields, ...overrides });
+    }
+
+    it('renders Refresh button', () => {
+      const { container } = completedSetup();
+      expect(container.querySelector('[data-test-id="completed-item-refresh-item1"]')).toBeInTheDocument();
+    });
+
+    it('renders Edit button', () => {
+      const { container } = completedSetup();
+      expect(container.querySelector('[data-test-id="completed-item-edit-item1"]')).toBeInTheDocument();
+    });
+
+    it('renders Delete button', () => {
+      const { container } = completedSetup();
+      expect(container.querySelector('[data-test-id="completed-item-delete-item1"]')).toBeInTheDocument();
+    });
+
+    it('calls onRefresh when Refresh is clicked', async () => {
+      const { container, props, user } = completedSetup();
+      const btn = container.querySelector('[data-test-id="completed-item-refresh-item1"]') as HTMLElement;
+      await user.click(btn);
+      expect(props.onRefresh).toHaveBeenCalledWith('item1');
+    });
+  });
+
+  describe('completed item (not refreshable)', () => {
+    it('does not render Refresh button when already refreshed', () => {
+      const item = createListItem(
+        'item1',
+        true,
+        [createField('f1', 'product', 'Refreshed Item', 'item1', { primary: true })],
+        { refreshed: true },
+      );
+      const { container } = setup({ item, fields: item.fields });
+      expect(container.querySelector('[data-test-id="completed-item-refresh-item1"]')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('read-only (shared, read permission)', () => {
+    function readOnlySetup(): ISetupReturn {
+      return setup({ permissions: { id1: 'read' } });
+    }
+
+    it('does not render action buttons', () => {
+      const { container } = readOnlySetup();
+      expect(container.querySelector('[data-test-id="not-completed-item-complete-item1"]')).not.toBeInTheDocument();
+      expect(container.querySelector('[data-test-id="not-completed-item-edit-item1"]')).not.toBeInTheDocument();
+      expect(container.querySelector('[data-test-id="not-completed-item-delete-item1"]')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('multi-select', () => {
+    it('shows checkbox when multi-select is active', () => {
+      const { container } = setup({ isMultiSelectActive: true });
+      expect(container.querySelector('[data-test-id="not-completed-item-select-item1"]')).toBeInTheDocument();
+    });
+
+    it('does not show checkbox when multi-select is inactive', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-id="not-completed-item-select-item1"]')).not.toBeInTheDocument();
+    });
+
+    it('checkbox is checked when selected', () => {
+      const { container } = setup({ isMultiSelectActive: true, isSelected: true });
+      const checkbox = container.querySelector('[data-test-id="not-completed-item-select-item1"]') as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+    });
+
+    it('calls onSelect when checkbox is clicked', async () => {
+      const { container, props, user } = setup({ isMultiSelectActive: true });
+      const checkbox = container.querySelector('[data-test-id="not-completed-item-select-item1"]') as HTMLElement;
+      await user.click(checkbox);
+      expect(props.onSelect).toHaveBeenCalledWith('item1');
+    });
+
+    it('uses completed-item-select prefix for completed items', () => {
+      const item = createListItem('item1', true, [createField('f1', 'product', 'Done', 'item1', { primary: true })]);
+      const { container } = setup({ item, fields: item.fields, isMultiSelectActive: true });
+      expect(container.querySelector('[data-test-id="completed-item-select-item1"]')).toBeInTheDocument();
+    });
+  });
+
+  describe('secondary fields display', () => {
+    it('renders date fields formatted', async () => {
+      const item = createListItem('item1', false, [
+        createField('f1', 'product', 'Book', 'item1', { primary: true }),
+        createField('f2', 'due', '2025-12-25', 'item1', { data_type: EListItemFieldType.DATE_TIME }),
+      ]);
+      const { container } = setup({ item, fields: item.fields });
+      // Should render formatted date (not raw ISO string)
+      expect(container.querySelector('[data-test-class="non-completed-item"]')).toBeInTheDocument();
+    });
+
+    it('renders dot separator between secondary fields', () => {
+      const item = createListItem('item1', false, [
+        createField('f1', 'product', 'Book', 'item1', { primary: true }),
+        createField('f2', 'author', 'Author A', 'item1'),
+        createField('f3', 'year', '2024', 'item1'),
+      ]);
+      const { container } = setup({ item, fields: item.fields });
+      const secondaryText = container.textContent;
+      expect(secondaryText).toContain('Author A');
+      expect(secondaryText).toContain('2024');
+    });
+  });
+
+  describe('completed state visual', () => {
+    it('applies completed styles', () => {
+      const item = createListItem('item1', true, [createField('f1', 'product', 'Done', 'item1', { primary: true })]);
+      const { container } = setup({ item, fields: item.fields });
+      const card = container.querySelector('[data-test-class="completed-item"]');
+      expect(card?.className).toContain('opacity-60');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('checkbox has aria-label', () => {
+      const { container } = setup({ isMultiSelectActive: true });
+      const checkbox = container.querySelector('input[type="checkbox"]');
+      expect(checkbox).toHaveAttribute('aria-label', 'Select Apples');
+    });
+  });
+});

--- a/src/components/domain/ListItemRow.tsx
+++ b/src/components/domain/ListItemRow.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+
+import { Card } from '../ui/Card';
+import { IconButton } from '../ui/IconButton';
+import { Badge } from '../ui/Badge';
+import { CheckIcon, EditIcon, RedoIcon, TrashIcon } from '../icons';
+import type { IListItem, IListItemField, IListItemFieldConfiguration, TUserPermissions } from 'typings';
+import { EListItemFieldType, EUserPermissions } from 'typings';
+import { prettyDueBy } from 'utils/format';
+
+export interface IListItemRowProps {
+  item: IListItem;
+  listId: string;
+  fields: IListItemField[];
+  fieldConfigurations: IListItemFieldConfiguration[];
+  isMultiSelectActive: boolean;
+  isSelected: boolean;
+  onSelect: (itemId: string) => void;
+  onComplete: (itemId: string) => void;
+  onRefresh: (itemId: string) => void;
+  onEdit: (itemId: string) => void;
+  onDelete: (itemId: string) => void;
+  permissions: TUserPermissions;
+}
+
+function getPrimaryFieldValue(fields: IListItemField[]): string {
+  if (!Array.isArray(fields) || fields.length === 0) {
+    return '';
+  }
+  const primary = fields.find((f) => f.primary === true);
+  if (primary?.data) {
+    return String(primary.data);
+  }
+  const fallback = fields.find((f) => f.primary !== true && f.data);
+  return fallback?.data ? String(fallback.data) : '';
+}
+
+function getSecondaryFields(fields: IListItemField[]): { label: string; value: string }[] {
+  if (!Array.isArray(fields) || fields.length === 0) {
+    return [];
+  }
+  const primaryFields = fields.filter((f) => f.primary === true);
+  const hasPrimaryField = primaryFields.length > 0 && primaryFields[0]?.data;
+  const fallbackPrimaryField = hasPrimaryField ? null : fields.find((f) => f.primary !== true && f.data);
+
+  return fields
+    .filter((f) => {
+      if (f.primary === true) {
+        return false;
+      }
+      if (f.id === fallbackPrimaryField?.id) {
+        return false;
+      }
+      return true;
+    })
+    .map((f) => {
+      if (f.data_type === EListItemFieldType.DATE_TIME && f.data) {
+        return { label: f.label, value: prettyDueBy(String(f.data)) };
+      }
+      return { label: f.label, value: f.data ? String(f.data) : '' };
+    });
+}
+
+export function ListItemRow(props: IListItemRowProps): React.JSX.Element {
+  const {
+    item,
+    fields,
+    isMultiSelectActive,
+    isSelected,
+    onSelect,
+    onComplete,
+    onRefresh,
+    onEdit,
+    onDelete,
+    permissions,
+  } = props;
+
+  const listId = item.list_id;
+  const permission = permissions[listId];
+  const canWrite = permission === EUserPermissions.WRITE;
+  const testClassPrefix = item.completed ? 'completed' : 'not-completed';
+  const testClass = item.completed ? 'completed-item' : 'non-completed-item';
+  const primaryValue = getPrimaryFieldValue(fields);
+  const secondaryFields = getSecondaryFields(fields);
+
+  const renderActionButtons = (): React.JSX.Element | null => {
+    if (!canWrite) {
+      return null;
+    }
+
+    return (
+      <div className="tw:flex tw:items-center tw:gap-1">
+        {item.completed ? (
+          item.refreshed ? null : (
+            <IconButton
+              icon={<RedoIcon size="sm" />}
+              variant="primary"
+              size="sm"
+              label="Refresh"
+              data-test-id={`completed-item-refresh-${item.id}`}
+              onClick={(e): void => {
+                e.stopPropagation();
+                onRefresh(item.id);
+              }}
+            />
+          )
+        ) : (
+          <IconButton
+            icon={<CheckIcon size="sm" />}
+            variant="success"
+            size="sm"
+            label="Complete"
+            data-test-id={`not-completed-item-complete-${item.id}`}
+            onClick={(e): void => {
+              e.stopPropagation();
+              onComplete(item.id);
+            }}
+          />
+        )}
+        <IconButton
+          icon={<EditIcon size="sm" />}
+          variant="default"
+          size="sm"
+          label="Edit"
+          data-test-id={`${testClassPrefix}-item-edit-${item.id}`}
+          onClick={(e): void => {
+            e.stopPropagation();
+            onEdit(item.id);
+          }}
+        />
+        <IconButton
+          icon={<TrashIcon size="sm" />}
+          variant="danger"
+          size="sm"
+          label="Delete"
+          data-test-id={`${testClassPrefix}-item-delete-${item.id}`}
+          onClick={(e): void => {
+            e.stopPropagation();
+            onDelete(item.id);
+          }}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <Card
+      variant="interactive"
+      selected={isMultiSelectActive && isSelected}
+      completed={item.completed}
+      data-test-class={testClass}
+      className="tw:flex tw:items-center tw:gap-3"
+    >
+      {isMultiSelectActive && (
+        <input
+          type="checkbox"
+          className="tw:w-5 tw:h-5 tw:cursor-pointer tw:flex-shrink-0"
+          checked={isSelected}
+          onChange={(): void => onSelect(item.id)}
+          data-test-id={`${testClassPrefix}-item-select-${item.id}`}
+          aria-label={`Select ${primaryValue || 'item'}`}
+        />
+      )}
+      <div className="tw:flex-1 tw:min-w-0">
+        <div className="tw:flex tw:items-center tw:justify-between tw:gap-2">
+          <div className="tw:flex-1 tw:min-w-0">
+            <div className="tw:text-base tw:font-medium tw:truncate">{primaryValue || 'Untitled Item'}</div>
+            {secondaryFields.length > 0 && (
+              <div className="tw:text-sm tw:text-[var(--color-text-secondary)] tw:truncate tw:mt-0.5">
+                {secondaryFields.map((field, index) => (
+                  <span key={field.label}>
+                    {index > 0 && <span className="tw:mx-1">&middot;</span>}
+                    <span>{field.value}</span>
+                  </span>
+                ))}
+              </div>
+            )}
+            {item.category && (
+              <div className="tw:mt-1">
+                <Badge>{item.category}</Badge>
+              </div>
+            )}
+          </div>
+          <div className="tw:flex-shrink-0">{renderActionButtons()}</div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/domain/MultiSelectBar.spec.tsx
+++ b/src/components/domain/MultiSelectBar.spec.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { render, type RenderResult } from '@testing-library/react';
+import userEvent, { type UserEvent } from '@testing-library/user-event';
+
+import { MultiSelectBar, type IMultiSelectBarProps, type IMultiSelectAction } from './MultiSelectBar';
+import { CheckIcon } from '../icons';
+
+interface ISetupReturn extends RenderResult {
+  props: IMultiSelectBarProps;
+  user: UserEvent;
+}
+
+function createAction(overrides: Partial<IMultiSelectAction> = {}): IMultiSelectAction {
+  return {
+    icon: <CheckIcon size="sm" />,
+    label: 'Complete',
+    onClick: vi.fn(),
+    variant: 'success',
+    testId: 'action-complete',
+    ...overrides,
+  };
+}
+
+function setup(suppliedProps: Partial<IMultiSelectBarProps> = {}): ISetupReturn {
+  const user = userEvent.setup();
+  const defaultProps: IMultiSelectBarProps = {
+    selectedCount: 3,
+    onClose: vi.fn(),
+    actions: [createAction()],
+  };
+  const props = { ...defaultProps, ...suppliedProps };
+  const component = render(<MultiSelectBar {...props} />);
+  return { ...component, props, user };
+}
+
+describe('MultiSelectBar', () => {
+  describe('rendering', () => {
+    it('renders with multi-select-bar data-test-id', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-id="multi-select-bar"]')).toBeInTheDocument();
+    });
+
+    it('renders selected count', async () => {
+      const { findByText } = setup({ selectedCount: 5 });
+      expect(await findByText('5 selected')).toBeVisible();
+    });
+
+    it('renders count with multi-select-count data-test-id', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-id="multi-select-count"]')).toBeInTheDocument();
+    });
+
+    it('renders close button with multi-select-close data-test-id', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-id="multi-select-close"]')).toBeInTheDocument();
+    });
+  });
+
+  describe('close button', () => {
+    it('calls onClose when close button is clicked', async () => {
+      const { container, props, user } = setup();
+      const closeBtn = container.querySelector('[data-test-id="multi-select-close"]') as HTMLElement;
+      await user.click(closeBtn);
+      expect(props.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('has aria-label for accessibility', () => {
+      const { container } = setup();
+      const closeBtn = container.querySelector('[data-test-id="multi-select-close"]');
+      expect(closeBtn).toHaveAttribute('aria-label', 'Exit multi-select');
+    });
+  });
+
+  describe('actions', () => {
+    it('renders action buttons with correct data-test-id', () => {
+      const { container } = setup();
+      expect(container.querySelector('[data-test-id="action-complete"]')).toBeInTheDocument();
+    });
+
+    it('calls action onClick when action button is clicked', async () => {
+      const action = createAction();
+      const { container, user } = setup({ actions: [action] });
+      const actionBtn = container.querySelector('[data-test-id="action-complete"]') as HTMLElement;
+      await user.click(actionBtn);
+      expect(action.onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders multiple action buttons', () => {
+      const actions = [
+        createAction({ testId: 'action-complete', label: 'Complete' }),
+        createAction({ testId: 'action-delete', label: 'Delete', variant: 'danger' }),
+        createAction({ testId: 'action-merge', label: 'Merge', variant: 'primary' }),
+      ];
+      const { container } = setup({ actions });
+      expect(container.querySelector('[data-test-id="action-complete"]')).toBeInTheDocument();
+      expect(container.querySelector('[data-test-id="action-delete"]')).toBeInTheDocument();
+      expect(container.querySelector('[data-test-id="action-merge"]')).toBeInTheDocument();
+    });
+
+    it('renders action with aria-label', () => {
+      const { container } = setup();
+      const actionBtn = container.querySelector('[data-test-id="action-complete"]');
+      expect(actionBtn).toHaveAttribute('aria-label', 'Complete');
+    });
+
+    it('renders no actions when empty array', () => {
+      const { container } = setup({ actions: [] });
+      const bar = container.querySelector('[data-test-id="multi-select-bar"]');
+      expect(bar?.querySelectorAll('button').length).toBe(1); // only close button
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has role="toolbar"', () => {
+      const { container } = setup();
+      const bar = container.querySelector('[data-test-id="multi-select-bar"]');
+      expect(bar).toHaveAttribute('role', 'toolbar');
+    });
+
+    it('has aria-label on toolbar', () => {
+      const { container } = setup();
+      const bar = container.querySelector('[data-test-id="multi-select-bar"]');
+      expect(bar).toHaveAttribute('aria-label', 'Multi-select actions');
+    });
+  });
+
+  describe('selected count variations', () => {
+    it('renders singular count', async () => {
+      const { findByText } = setup({ selectedCount: 1 });
+      expect(await findByText('1 selected')).toBeVisible();
+    });
+
+    it('renders zero count', async () => {
+      const { findByText } = setup({ selectedCount: 0 });
+      expect(await findByText('0 selected')).toBeVisible();
+    });
+  });
+});

--- a/src/components/domain/MultiSelectBar.tsx
+++ b/src/components/domain/MultiSelectBar.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { IconButton } from '../ui/IconButton';
+
+export interface IMultiSelectAction {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  variant?: 'default' | 'success' | 'danger' | 'primary';
+  testId: string;
+}
+
+export interface IMultiSelectBarProps {
+  selectedCount: number;
+  onClose: () => void;
+  actions: IMultiSelectAction[];
+}
+
+export function MultiSelectBar(props: IMultiSelectBarProps): React.JSX.Element {
+  const { selectedCount, onClose, actions } = props;
+
+  return (
+    <div
+      className={
+        'tw:flex tw:items-center tw:gap-3 tw:px-4 tw:py-2 ' +
+        'tw:bg-[var(--color-surface-raised)] tw:border tw:border-[var(--color-border)] ' +
+        'tw:rounded-[var(--radius-lg)] tw:shadow-[var(--shadow-md)]'
+      }
+      data-test-id="multi-select-bar"
+      role="toolbar"
+      aria-label="Multi-select actions"
+    >
+      <button
+        type="button"
+        className={
+          'tw:flex tw:items-center tw:justify-center tw:w-8 tw:h-8 tw:rounded-full ' +
+          'tw:text-[var(--color-text-secondary)] tw:hover:bg-[var(--color-surface-overlay)] ' +
+          'tw:cursor-pointer tw:transition-colors'
+        }
+        data-test-id="multi-select-close"
+        onClick={onClose}
+        aria-label="Exit multi-select"
+      >
+        &times;
+      </button>
+      <span
+        className="tw:text-sm tw:font-medium tw:text-[var(--color-text-primary)] tw:whitespace-nowrap"
+        data-test-id="multi-select-count"
+      >
+        {selectedCount} selected
+      </span>
+      <div className="tw:flex tw:items-center tw:gap-1 tw:ml-auto">
+        {actions.map((action) => (
+          <IconButton
+            key={action.testId}
+            icon={action.icon}
+            variant={action.variant ?? 'default'}
+            size="sm"
+            label={action.label}
+            data-test-id={action.testId}
+            onClick={action.onClick}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Build the complex domain components for the UI redesign:
- ListCard: list card with state-aware action buttons, multi-select, and permission-based visibility (incomplete/completed/pending states)
- ListItemRow: item row with primary/secondary fields, category badge, completion actions, and multi-select support
- MultiSelectBar: contextual toolbar with dynamic actions and selected count

All components use Phase 2A Tailwind-based base components (Card, IconButton, Badge, Checkbox) and preserve existing data-test-id/data-test-class attributes for feature test compatibility. Not yet integrated into pages (Phase 3).