### PR TITLE
WIP: fix list row action clicks and disable sheet animation in dev.

### DIFF
--- a/src/components/domain/ListCard.spec.tsx
+++ b/src/components/domain/ListCard.spec.tsx
@@ -116,6 +116,13 @@ describe('ListCard', () => {
       await user.click(btn);
       expect(props.onDelete).toHaveBeenCalledWith('list1');
     });
+
+    it('does not call onClick when Delete is clicked', async () => {
+      const { container, props, user } = setup();
+      const btn = container.querySelector('[data-test-id="incomplete-list-trash"]') as HTMLElement;
+      await user.click(btn);
+      expect(props.onClick).not.toHaveBeenCalled();
+    });
   });
 
   describe('incomplete list (shared, write)', () => {

--- a/src/components/domain/ListCard.tsx
+++ b/src/components/domain/ListCard.tsx
@@ -58,7 +58,11 @@ export function ListCard(props: IListCardProps): React.JSX.Element {
   const isOwner = userId === list.owner_id;
   const testClass = getTestClass(list);
 
-  const handleClick = (): void => {
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>): void => {
+    if ((event.target as HTMLElement).closest("button")) {
+      return;
+    }
+
     if (isMultiSelectActive) {
       onSelect(listId);
     } else {
@@ -67,9 +71,9 @@ export function ListCard(props: IListCardProps): React.JSX.Element {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent): void => {
-    if (e.key === 'Enter' || e.key === ' ') {
+    if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
-      handleClick();
+      handleClick(e as unknown as React.MouseEvent<HTMLDivElement>);
     }
   };
 

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -75,7 +75,7 @@ export function createDragEndHandler(onClose: () => void): (event: unknown, info
 
 export function BottomSheet(props: IBottomSheetProps): React.JSX.Element {
   const { isOpen, onClose, title, children, testId } = props;
-  const shouldAnimate = !prefersReducedMotion() && import.meta.env.MODE !== 'test';
+  const shouldAnimate = import.meta.env.PROD && !prefersReducedMotion();
   const previousActiveElementRef = React.useRef<HTMLElement | null>(null);
   const sheetRef = React.useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
Ignore card navigation when a row action button is clicked, and skip BottomSheet framer-motion animation outside production so Capybara can see confirm/edit sheets during feature tests.

lists_spec.rb delete/reject/edit examples still timing out on confirm-modal waits in groceries_features — re-run feature suite after restarting the dev client with this build.